### PR TITLE
find bash from the environment

### DIFF
--- a/cmc
+++ b/cmc
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # ControlMaster Controller - Eases management of SSH ControlMaster connections
 #

--- a/test_cmc
+++ b/test_cmc
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -o errexit
 set -o errtrace
 set -o nounset


### PR DESCRIPTION
Bash isn't always at /bin/bash, so make CMC more portable by finding it using the environment. For example, NixOS does not have a `/bin/bash`.